### PR TITLE
fix: Change platform specification in Gemfile.lock to support all Ruby platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   pull_request:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   scan_ruby:
@@ -55,7 +55,10 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-
+    env:
+      RAILS_ENV: test
+      DATABASE_URL: mysql2://root@127.0.0.1:3306
+      #REDIS_URL: redis://localhost:6379/0
     services:
       mysql:
         image: mysql
@@ -63,13 +66,17 @@ jobs:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
 
-      # redis:
-      #   image: redis
-      #   ports:
-      #     - 6379:6379
-      #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+    # redis:
+    #   image: redis
+    #   ports:
+    #     - 6379:6379
+    #   options: --health-cmd "redis-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
 
     steps:
       - name: Install packages
@@ -84,12 +91,15 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
+      - name: Database setup
+        run: |
+          bin/rails db:create
+          #bin/rails db:schema:load
       - name: Run tests
-        env:
-          RAILS_ENV: test
-          DATABASE_URL: mysql2://127.0.0.1:3306
-          # REDIS_URL: redis://localhost:6379/0
-        run: bin/rails db:test:prepare test test:system
+        run: |
+          #bin/rails db:test:prepare
+          bin/rails test
+          bin/rails test:system
 
       - name: Keep screenshots from failed system tests
         uses: actions/upload-artifact@v4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,8 +276,7 @@ GEM
     zeitwerk (2.6.17)
 
 PLATFORMS
-  aarch64-linux
-  arm64-darwin-22
+  ruby
 
 DEPENDENCIES
   bootsnap


### PR DESCRIPTION
Modified the Gemfile.lock file to replace specific platform entries (aarch64-linux, arm64-darwin-22) with the more generic `ruby` platform. This change ensures compatibility across all Ruby-supported environments, making the project more versatile and eliminating platform-specific constraints.












<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Bug fix: CIジョブの実行を修正し、MySQLデータベース設定に`test_db`を追加
- Refactor: `Gemfile.lock`ファイルのプラットフォームエントリを`ruby`に置き換えて互換性を向上
- Chore: テストジョブの環境変数とサービス設定を微調整し、MySQLおよびRedisの設定をコメントアウト
- Test: テスト実行スクリプトを微調整し、Redis関連の設定を修正
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->